### PR TITLE
Update version to 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OmniAuth Y8 Account (0.2.0)
+# OmniAuth Y8 Account (0.2.1)
 
 This is the official OmniAuth strategy for authenticating to [Y8 Account](https://account.y8.com). To
 use it, you'll need Y8 Account consumer application ID and SECRET.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OmniAuth Y8 Account (0.2.0)
 
 This is the official OmniAuth strategy for authenticating to [Y8 Account](https://account.y8.com). To
-use it, you'll need Y* Account consumer application ID and SECRET.
+use it, you'll need Y8 Account consumer application ID and SECRET.
 
 ## Basic Usage
 Currently, you have to initialize OmniAuth (with Y8 Account strategy) like this:
@@ -12,23 +12,23 @@ This way, Y8 Account strategy will be initialized with the set of default fields
 
 ```ruby
 DEFAULT =
-  [
-    "nickname",
-    "first_name",
-    "last_name",
-    "email",
-    "language",
-    "gender",
-    "street_address",
-    "city",
-    "country",
-    "state_or_province",
-    "zip",
-    "dob",
-    "level",
-    "avatars",
-    "version",
-    "risk"
+  %w[
+    nickname
+    first_name
+    last_name
+    email
+    language
+    gender
+    street_address
+    city
+    country
+    state_or_province
+    zip
+    dob
+    level
+    avatars
+    version
+    risk
   ]
 ```
 
@@ -45,8 +45,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :y8_account, APP_CONFIG[:app_id], APP_CONFIG[:app_secret],
            :client_options => {:site => "http://custom.y8_account.server.org/",
                                :authorize_url => "http://custom.y8_account.server.org/oauth/authorize",
-                               :token_url => "http://custom.y8_account.server.org/oauth/token",
-                               :ssl => {:verify => false} # if your provider does not use ssl
+                               :token_url => "http://custom.y8_account.server.org/oauth/token"
                              }
 end
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,12 @@
 #!/usr/bin/env rake
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
 desc 'Default: run specs.'
-task :default => :spec
+task default: :spec
 
-desc "Run specs"
+desc 'Run specs'
 RSpec::Core::RakeTask.new
 
 desc 'Run specs'
-task :default => :spec
+task default: :spec

--- a/lib/omniauth-y8_account/default_fields.rb
+++ b/lib/omniauth-y8_account/default_fields.rb
@@ -1,23 +1,23 @@
 module OmniAuth
   module Y8Account
     DEFAULT =
-      [
-        "nickname",
-        "first_name",
-        "last_name",
-        "email",
-        "language",
-        "gender",
-        "street_address",
-        "city",
-        "country",
-        "state_or_province",
-        "zip",
-        "dob",
-        "level",
-        "avatars",
-        "version",
-        "risk"
+      %w[
+        nickname
+        first_name
+        last_name
+        email
+        language
+        gender
+        street_address
+        city
+        country
+        state_or_province
+        zip
+        dob
+        level
+        avatars
+        version
+        risk
       ]
   end
 end

--- a/lib/omniauth-y8_account/version.rb
+++ b/lib/omniauth-y8_account/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Y8Account
-    VERSION = '0.2.0'
+    VERSION = '0.2.1'
   end
 end

--- a/lib/omniauth/strategies/y8_account.rb
+++ b/lib/omniauth/strategies/y8_account.rb
@@ -3,7 +3,6 @@ require 'omniauth-oauth2'
 module OmniAuth
   module Strategies
     class Y8Account < OmniAuth::Strategies::OAuth2
-
       option :name, 'y8_account'
 
       option :fields, OmniAuth::Y8Account::DEFAULT

--- a/omniauth-y8-account.gemspec
+++ b/omniauth-y8-account.gemspec
@@ -11,8 +11,8 @@ Gem::Specification.new do |gem|
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n")
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  gem.name          = "omniauth-y8_account"
-  gem.require_paths = ["lib"]
+  gem.name          = 'omniauth-y8_account'
+  gem.require_paths = ['lib']
   gem.version       = OmniAuth::Y8Account::VERSION
 
   gem.add_dependency 'omniauth', '~> 1.9'

--- a/omniauth-y8-account.gemspec
+++ b/omniauth-y8-account.gemspec
@@ -2,8 +2,8 @@
 require File.expand_path('../lib/omniauth-y8_account/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Vlad Shvedov", "Hery Ramihajamalala"]
-  gem.email         = ["vshvedov@heliostech.hk", "hery@heliostech.fr"]
+  gem.authors       = ['François Turbelin', 'Tomas Brazys']
+  gem.email         = ['francois.t@webgroup-limited.com', 'tomas.b@webgroup-limited.com']
   gem.description   = %q{Official OmniAuth strategy for Y8 Account.}
   gem.summary       = %q{Official OmniAuth strategy for Y8 Account.}
   gem.homepage      = 'https://github.com/Y8Games/omniauth-y8_account'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,4 +16,3 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 end
-


### PR DESCRIPTION
I was pushing directly on the master branch initially, but it is not the way it should be.

Here on 0.2.1, we have minor changes for final integration of new gem name in external projects.

The big changes of the 0.2.0 version was:
- Renaming the gem
- Bump omniauth from 1.1 to 1.9 version
- Bump omniauth-oauth2 from 1.1 to 1.7 version